### PR TITLE
gulp-all should always drain stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function () {
   var tasks = args.map(function (task) {
     return new Promise(function (res, rej) {
       task
+        .resume()
         .on('finish', res)
         .on('error', rej)
     })


### PR DESCRIPTION
As described in https://github.com/amio/gulp-all/issues/1, and as following gulp's implementation https://github.com/gulpjs/gulp/issues/707#issuecomment-63245580, this pull request will drain all stream taken 
