### PR TITLE
Add Promise check to support nested gulp-all

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = function () {
     : [].slice.call(arguments)
 
   var tasks = args.map(function (task) {
+    if(task instanceof Promise)
+      return task;
+    
     return new Promise(function (res, rej) {
       exhaust(task)
         .on('finish', res)


### PR DESCRIPTION
Sometimes we hope to use nested gulp-all like this.

``` javascript
var bundles1 = [/*...*/], bundles2 = [/*...*/];

gulp.task('default', function() {
    return all(
        all(bundles1.map(function(bundle){...}),
        all(bundles2.map(function(bundle){...}),
        gulp.src('./some.js').pipe(gulp.dest('tmp')),
        gulp.src('./some.css').pipe(gulp.dest('tmp'))
    )
});
```

However, it will caught an error because the argument is a Promise.

```
[20:47:38] TypeError: undefined is not a function
    at /Volumes/Home/yusen/Projects/GitHub/gulp-all/index.js:13:10
    at /Volumes/Home/yusen/Projects/GitHub/gulp-all/index.js:11:12
```
